### PR TITLE
Add support to zustand version 5 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"eslint": "^8.56.0",
 		"prettier": "^3.1.1",
 		"tsconfig": "workspace:*",
-		"turbo": "^1.11.2"
+		"turbo": "^2.3.3"
 	},
 	"packageManager": "pnpm@8.6.10",
 	"name": "turbo-template"

--- a/packages/zustand-sync-tabs/package.json
+++ b/packages/zustand-sync-tabs/package.json
@@ -35,7 +35,7 @@
 		"zustand": "^4.4.7"
 	},
 	"peerDependencies": {
-		"zustand": "^3 || ^4"
+		"zustand": "^3 || ^4 || ^5"
 	},
 	"keywords": [
 		"web",

--- a/turbo.json
+++ b/turbo.json
@@ -1,16 +1,23 @@
 {
-	"$schema": "https://turbo.build/schema.json",
-	"globalDependencies": ["**/.env.*local"],
-	"pipeline": {
-		"build": {
-			"dependsOn": ["^build"],
-			"outputs": [".next/**", "!.next/cache/**"]
-		},
-		"lint": {},
-		"test": {},
-		"dev": {
-			"cache": false,
-			"persistent": true
-		}
-	}
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    "**/.env.*local"
+  ],
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ]
+    },
+    "lint": {},
+    "test": {},
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
+  }
 }


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration files to ensure compatibility and improve project structure. The most important changes include upgrading the `turbo` and `zustand` dependencies and restructuring the `turbo.json` file for better readability.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15): Upgraded `turbo` from version 1.11.2 to 2.3.3.
* [`packages/zustand-sync-tabs/package.json`](diffhunk://#diff-4c9f2b576a912bf1c26556c5ad2476dc8c469f21c0150788e913919686c58e1bL38-R38): Updated the `zustand` peer dependency to include version 5.

Configuration improvements:

* [`turbo.json`](diffhunk://#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3L3-R14): Restructured the file for better readability by changing `pipeline` to `tasks` and formatting the `globalDependencies` and `tasks` sections.

This closes https://github.com/react18-tools/zustand-sync-tabs/issues/10